### PR TITLE
Add check if progress window exists

### DIFF
--- a/ffmpeg.py
+++ b/ffmpeg.py
@@ -43,7 +43,8 @@ class FFmpegInstaller:
             return
         
         progress_win = mw.progress.start(immediate=True, label="Downloading FFmpeg...", min = 0)
-        progress_win.show()
+        if progress_win:
+            progress_win.show()
         try:
             temp_file_path = join(self.addonPath, "ffmpeg.zip")
             # Download zip

--- a/voicevox_gen.py
+++ b/voicevox_gen.py
@@ -262,6 +262,45 @@ class MyDialog(qt.QDialog):
 
         self.grid_layout.addWidget(speed_label, 5, 0, 1, 2)
         self.grid_layout.addWidget(speed_slider, 5, 3, 1, 2)
+
+        # Intonation slider
+        intonation_slider = QSlider(qt.Qt.Orientation.Horizontal)
+        intonation_slider.setMinimum(1)
+        intonation_slider.setMaximum(200)
+        intonation_slider.setValue(config.get('intonation_slider_value') or 100)
+        
+        intonation_label = QLabel(f'Intonation scale {intonation_slider.value() / 100}')
+        
+        intonation_slider.valueChanged.connect(update_slider(intonation_slider, intonation_label, 'intonation_slider_value', 'Intonation scale'))
+
+        self.grid_layout.addWidget(intonation_label, 6, 0, 1, 2)
+        self.grid_layout.addWidget(intonation_slider, 6, 3, 1, 2)
+
+        # Initial silence slider
+        initial_silence_slider = QSlider(qt.Qt.Orientation.Horizontal)
+        initial_silence_slider.setMinimum(0)
+        initial_silence_slider.setMaximum(150)
+        initial_silence_slider.setValue(config.get('initial_silence_slider_value') or 10)
+
+        initial_silence_label = QLabel(f'Initial silence scale {initial_silence_slider.value() / 100}')
+
+        initial_silence_slider.valueChanged.connect(update_slider(initial_silence_slider, initial_silence_label, 'initial_silence_slider_value', 'Initial silence scale'))
+
+        self.grid_layout.addWidget(initial_silence_label, 7, 0, 1, 2)
+        self.grid_layout.addWidget(initial_silence_slider, 7, 3, 1, 2)
+
+        # Final silence slider
+        final_silence_slider = QSlider(qt.Qt.Orientation.Horizontal)
+        final_silence_slider.setMinimum(0)
+        final_silence_slider.setMaximum(150)
+        final_silence_slider.setValue(config.get('final_silence_slider_value') or 10)
+
+        final_silence_label = QLabel(f'Final silence length {final_silence_slider.value() / 100}')
+
+        final_silence_slider.valueChanged.connect(update_slider(final_silence_slider, final_silence_label, 'final_silence_slider_value', 'Final silence scale'))
+
+        self.grid_layout.addWidget(final_silence_label, 8, 0, 1, 2)
+        self.grid_layout.addWidget(final_silence_slider, 8, 3, 1, 2)
         
         layout.addLayout(self.grid_layout)
 
@@ -305,6 +344,12 @@ def GenerateAudioQuery(text_and_speaker_index_tuple, config):
             j['volumeScale'] = config.get('volume_slider_value') / 100;
         if config.get('pitch_slider_value'):
             j['pitchScale'] = config.get('pitch_slider_value') / 100;
+        if config.get('intonation_slider_value'):
+            j['intonationScale'] = config.get('intonation_slider_value') / 100;
+        if config.get('initial_silence_slider_value'):
+            j['prePhonemeLength'] = config.get('initial_silence_slider_value') / 100;
+        if config.get('final_silence_slider_value'):
+            j['postPhonemeLength'] = config.get('final_silence_slider_value') / 100;
         result = json.dumps(j, ensure_ascii=False).encode('utf8')
         return result
     except Exception as e:


### PR DESCRIPTION
 Running the addon for the first time results in the following error for me: 
 ```
Anki 24.06.2 (33a92379) (src) (ao)
Python 3.12.4 Qt 6.7.1 PyQt 6.7.0
Platform: Linux-6.9.6-zen1-1-zen-x86_64-with-glibc2.39

Traceback (most recent call last):
  File "/usr/lib/python3.12/site-packages/aqt/progress.py", line 119, in handler
    func()
  File "/usr/lib/python3.12/site-packages/aqt/main.py", line 219, in on_window_init
    fn()
  File "/usr/lib/python3.12/site-packages/aqt/main.py", line 318, in setupProfile
    self.loadProfile()
  File "/usr/lib/python3.12/site-packages/aqt/main.py", line 530, in loadProfile
    gui_hooks.profile_did_open()
  File "/usr/lib/python3.12/site-packages/_aqt/hooks.py", line 4107, in __call__
    anki.hooks.runHook("profileLoaded")
  File "/usr/lib/python3.12/site-packages/anki/hooks.py", line 34, in runHook
    func(*args)
  File "/home/user/.local/share/Anki2/addons21/366960193/ffmpeg.py", line 46, in GetFFmpegIfNotExist
    progress_win.show()
    ^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'show'
```

Simply adding an if-check before the `progress_win.show()` fixes it for me.