### PR TITLE
Add ability to use opus instead of mp3

### DIFF
--- a/ffmpeg.py
+++ b/ffmpeg.py
@@ -75,7 +75,7 @@ class FFmpegInstaller:
 
 ffmpegInstaller = FFmpegInstaller()
 
-def ConvertWavToMp3(wav_data):
+def ConvertWav(wav_data, format):
     if not ffmpegInstaller.can_convert:
         return None
     try:
@@ -86,8 +86,17 @@ def ConvertWavToMp3(wav_data):
         else:
             # On MacOS, subprocess.STARTUPINFO() does not exist
             startupinfo = None
-        
-        process = subprocess.Popen([ffmpegInstaller.full_ffmpeg_path, '-y', '-nostats', '-hide_banner', '-i', 'pipe:', '-f', 'mp3', "-qscale:a", "3", '-'], stdout = subprocess.PIPE, stderr = subprocess.PIPE, stdin = subprocess.PIPE, startupinfo=startupinfo)
+
+        ffmpeg_command = [ffmpegInstaller.full_ffmpeg_path, '-y', '-nostats', '-hide_banner', '-i', 'pipe:', '-f', format]
+
+        if format == "mp3":
+            ffmpeg_command +=  ["-qscale:a", "3"]
+        elif format == "opus":
+            ffmpeg_command +=  ["-b:a", "32k"]
+
+        ffmpeg_command.append('-')
+
+        process = subprocess.Popen(ffmpeg_command, stdout = subprocess.PIPE, stderr = subprocess.PIPE, stdin = subprocess.PIPE, startupinfo=startupinfo)
         output = process.communicate(input=wav_data)[0]
         return output
     except Exception as e:

--- a/voicevox_gen.py
+++ b/voicevox_gen.py
@@ -214,6 +214,11 @@ class MyDialog(qt.QDialog):
         append_audio_checked = config.get('append_audio') or "false"
         self.append_audio.setChecked(True if append_audio_checked == "true" else False)
         self.grid_layout.addWidget(self.append_audio, 2, 0)
+
+        self.use_opus =  qt.QCheckBox("Use opus instead of mp3")
+        use_opus_checked = config.get('use_opus') or "false"
+        self.use_opus.setChecked(True if use_opus_checked == "true" else False)
+        self.grid_layout.addWidget(self.use_opus, 2, 1)
         
         self.cancel_button = qt.QPushButton("Cancel")
         self.generate_button = qt.QPushButton("Generate Audio")
@@ -416,6 +421,7 @@ def onVoicevoxOptionSelected(browser):
         config['last_speaker_name'] = speaker_combo_text
         config['last_style_name'] = style_combo_text
         config['append_audio'] = "true" if dialog.append_audio.isChecked() else "false"
+        config['use_opus'] = "true" if dialog.use_opus.isChecked() else "false"
         mw.addonManager.writeConfig(__name__, config)
 
         progress_window = qt.QWidget(None)
@@ -491,10 +497,11 @@ def onVoicevoxOptionSelected(browser):
                     
                     audio_extension = "wav"
 
-                    new_audio_data = ffmpeg.ConvertWavToMp3(audio_data)
+                    new_audio_format = "opus" if config['use_opus'] == "true" else "mp3"
+                    new_audio_data = ffmpeg.ConvertWav(audio_data, new_audio_format)
                     if new_audio_data != None:
                         audio_data = new_audio_data
-                        audio_extension = "mp3"
+                        audio_extension = new_audio_format
 
                     file_id = str(uuid.uuid4())
                     filename = f"VOICEVOX_{file_id}.{audio_extension}"


### PR DESCRIPTION
[Opus](https://en.wikipedia.org/wiki/Opus_(audio_format)) is a modern,  standardized and open audio format which beats mp3 on essentially every test of performance. This PR adds the ability to use opus audio, providing perceptually improved audio at less than half of the filesize compared to the default mp3 encoding options.

Other Japanese/Anki related projects like [mpvacious](https://github.com/Ajatt-Tools/mpvacious) and [Yomichan Local Audio Server](https://github.com/themoeway/local-audio-yomichan) provide options to use opus.

There is one large caveat to using opus, which is that [AnkiMobile cannot play them](https://forums.ankiweb.net/t/ogg-files-suported-in-anki-mobile/4171) due to... iOS stuff. However Android users can play them just fine using AnkiDroid. It's for this reason only that I don't recommend turning this on by default.

Tested and working on Linux + Windows (I don't own a Mac)

![image](https://github.com/user-attachments/assets/2cbbf4d9-98df-41be-8b07-bd8758bd3687)
