### PR TITLE
Raise timeout on audio synthesis commands

### DIFF
--- a/voicevox_gen.py
+++ b/voicevox_gen.py
@@ -361,7 +361,7 @@ def GenerateAudioQuery(text_and_speaker_index_tuple, config):
         raise Exception(f"Unable to generate audio for the following text: `{text}`.\nResponse: {audio_query_response.text if audio_query_response is not None else 'None'}\n{traceback.format_exc()}")
 
 def SynthesizeAudio(audio_query_json, speaker_index):
-    synthesis_response = requests.post("http://127.0.0.1:50021/synthesis?speaker=" + str(speaker_index), data=audio_query_json, timeout=5)
+    synthesis_response = requests.post("http://127.0.0.1:50021/synthesis?speaker=" + str(speaker_index), data=audio_query_json, timeout=30)
     if synthesis_response.status_code != 200:
         return None
     return synthesis_response.content
@@ -373,7 +373,7 @@ def MultiSynthesizeAudio(audio_queries, speaker_index): # NOTE: This returns a z
     # Create json array of queries
     combined = b"[" + b','.join(audio_queries) + b"]"
 
-    synthesis_response = requests.post("http://127.0.0.1:50021/multi_synthesis?speaker=" + str(speaker_index), data=combined, timeout=5)
+    synthesis_response = requests.post("http://127.0.0.1:50021/multi_synthesis?speaker=" + str(speaker_index), data=combined, timeout=30)
     if synthesis_response.status_code != 200:
         return None
     return synthesis_response.content 

--- a/voicevox_gen.py
+++ b/voicevox_gen.py
@@ -337,7 +337,7 @@ def GenerateAudioQuery(text_and_speaker_index_tuple, config):
     try:
         text = text_and_speaker_index_tuple[0]
         speaker_index = text_and_speaker_index_tuple[1]
-        audio_query_response = requests.post("http://127.0.0.1:50021/audio_query?speaker=" + str(speaker_index) + "&text=" + urllib.parse.quote(text, safe=''), timeout=5)
+        audio_query_response = requests.post("http://127.0.0.1:50021/audio_query?speaker=" + str(speaker_index) + "&text=" + urllib.parse.quote(text, safe=''))
         if audio_query_response.status_code != 200:
             raise Exception(f"Unable to generate audio for the following text: `{text}`. Response code was {audio_query_response.status_code}\nResponse:{audio_query_response.text}")
             
@@ -361,7 +361,7 @@ def GenerateAudioQuery(text_and_speaker_index_tuple, config):
         raise Exception(f"Unable to generate audio for the following text: `{text}`.\nResponse: {audio_query_response.text if audio_query_response is not None else 'None'}\n{traceback.format_exc()}")
 
 def SynthesizeAudio(audio_query_json, speaker_index):
-    synthesis_response = requests.post("http://127.0.0.1:50021/synthesis?speaker=" + str(speaker_index), data=audio_query_json, timeout=30)
+    synthesis_response = requests.post("http://127.0.0.1:50021/synthesis?speaker=" + str(speaker_index), data=audio_query_json)
     if synthesis_response.status_code != 200:
         return None
     return synthesis_response.content
@@ -373,7 +373,7 @@ def MultiSynthesizeAudio(audio_queries, speaker_index): # NOTE: This returns a z
     # Create json array of queries
     combined = b"[" + b','.join(audio_queries) + b"]"
 
-    synthesis_response = requests.post("http://127.0.0.1:50021/multi_synthesis?speaker=" + str(speaker_index), data=combined, timeout=30)
+    synthesis_response = requests.post("http://127.0.0.1:50021/multi_synthesis?speaker=" + str(speaker_index), data=combined)
     if synthesis_response.status_code != 200:
         return None
     return synthesis_response.content 


### PR DESCRIPTION
When using the addon to batch generate audio, I got random failures from `MultiSynthesizeAudio` because the 5s timeout was too low for generating audio for four sentences at once. Raising to 10s eliminated it for me, so I think 30s should be safe while also not being too long.